### PR TITLE
Fix Incorrect Inclusion of API_KEY in chat.completions.create Call

### DIFF
--- a/betterocr/detect.py
+++ b/betterocr/detect.py
@@ -70,9 +70,14 @@ def detect_text(
     print("=====")
     print(prompt)
 
-    api_key = os.environ["OPENAI_API_KEY"]
-    if "API_KEY" in options["openai"] and options["openai"]["API_KEY"] != "":
-        api_key = options["openai"]["API_KEY"]
+    # Prioritize user-specified API_KEY
+    api_key = options["openai"].get("API_KEY", os.environ.get("OPENAI_API_KEY"))
+
+    # Make a shallow copy of the openai options and remove the API_KEY
+    openai_options = options["openai"].copy()
+    if "API_KEY" in openai_options:
+        del openai_options["API_KEY"]
+
     client = OpenAI(
         api_key=api_key,
     )
@@ -83,7 +88,7 @@ def detect_text(
         messages=[
             {"role": "user", "content": prompt},
         ],
-        **options["openai"],
+        **openai_options,
     )
     output = completion.choices[0].message.content
     print("[*] LLM", output)
@@ -147,9 +152,14 @@ def detect_boxes(
     print("=====")
     print(prompt)
 
-    api_key = os.environ["OPENAI_API_KEY"]
-    if "API_KEY" in options["openai"] and options["openai"]["API_KEY"] != "":
-        api_key = options["openai"]["API_KEY"]
+    # Prioritize user-specified API_KEY
+    api_key = options["openai"].get("API_KEY", os.environ.get("OPENAI_API_KEY"))
+
+    # Make a shallow copy of the openai options and remove the API_KEY
+    openai_options = options["openai"].copy()
+    if "API_KEY" in openai_options:
+        del openai_options["API_KEY"]
+
     client = OpenAI(
         api_key=api_key,
     )
@@ -160,7 +170,7 @@ def detect_boxes(
         messages=[
             {"role": "user", "content": prompt},
         ],
-        **options["openai"],
+        **openai_options,
     )
     output = completion.choices[0].message.content
     output = output.replace("\n", "")


### PR DESCRIPTION
This PR addresses a bug  where the `API_KEY` was erroneously included in the parameters of the chat.completions.create() method, leading to a `TypeError`.  The error in question:
```
Traceback (most recent call last):
  File "/Users/easto/Library/Mobile Documents/com~apple~CloudDocs/Projects/spine-reader/better.py", line 4, in <module>
    text = betterocr.detect_text(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/easto/Library/Mobile Documents/com~apple~CloudDocs/Projects/spine-reader/venv/lib/python3.11/site-packages/betterocr/detect.py", line 83, in detect_text
    completion = client.chat.completions.create(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/easto/Library/Mobile Documents/com~apple~CloudDocs/Projects/spine-reader/venv/lib/python3.11/site-packages/openai/_utils/_utils.py", line 299, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
TypeError: Completions.create() got an unexpected keyword argument 'API_KEY'
```

The provided fix prioritizes the user-specified `API_KEY` when initializing the OpenAI client and ensures that the API_KEY is not passed along with other options to the `completions.create()` call.